### PR TITLE
Remove extra check for Client-SSL-Warning header

### DIFF
--- a/lib/WWW/Splunk/API.pm
+++ b/lib/WWW/Splunk/API.pm
@@ -176,13 +176,6 @@ sub request {
 	$self->{agent}->add_handler (response_header => sub {
 		my($response, $ua, $h) = @_;
 
-		# Deal with HTTPS errors
-		# newer LWP::UserAgent does this right
-		if ($_ = $response->header ('Client-SSL-Warning')) {
-			# Why does LWP tolerate these by default?
-			croak "SSL Error: $_" unless $self->{unsafe_ssl};
-		}
-
 		# Do not think of async processing of error responses
 		return 0 unless $response->is_success;
 


### PR DESCRIPTION
We must not treat this header as an SSL failure, its only meaning is LWP didn't know if we verified certificate or not.