### PR TITLE
Proper handling of HTTP 204 response

### DIFF
--- a/lib/WWW/Splunk/API.pm
+++ b/lib/WWW/Splunk/API.pm
@@ -169,7 +169,7 @@ sub request {
 		$request = new HTTP::Request ($method, $url);
 	}
 
-	my $content_type;
+	my $content_type = '';
 	my $buffer;
 
 	$self->{agent}->remove_handler ('response_header');
@@ -179,10 +179,14 @@ sub request {
 		# Do not think of async processing of error responses
 		return 0 unless $response->is_success;
 
-		# Decide if we're going async
-		$response->header ('Content-Type') =~ /^([^\s;]+)/
-			or croak "Missing or invalid Content-Type: $_";
-		$content_type = $1;
+		my $content_type_header = $response->header('Content-Type') // '';
+		if ($content_type_header =~ /^([^\s;]+)/) {
+			$content_type = $1;
+		} elsif ($response->code ne 204) {
+			# Sometimes splunk return HTTP 204 NO CONTENT during poll_search() call,
+			# Content-Type header is empty in this case. We must not croak in this case.
+			croak "Missing or invalid Content-Type: $content_type_header";
+		}
 
 		if ($callback) {
 			$response->{default_add_content} = 0;


### PR DESCRIPTION
We must not croak() if Splunk returned 204 with no content type